### PR TITLE
TypeError: this.input.chunk is not a function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lezer/cpp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "lezer-based C++ grammar",
   "main": "dist/index.cjs",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   "author": "Marijn Haverbeke <marijnh@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "@lezer/generator": "^1.0.0",
-    "mocha": "^9.0.1",
-    "rollup": "^2.52.2",
-    "@rollup/plugin-node-resolve": "^9.0.0"
+    "@lezer/generator": "^1.1.3",
+    "@rollup/plugin-node-resolve": "^15.0.1",
+    "mocha": "^10.2.0",
+    "rollup": "^3.7.4"
   },
   "dependencies": {
-    "@lezer/highlight": "^1.0.0",
-    "@lezer/lr": "^1.0.0"
+    "@lezer/highlight": "^1.1.3",
+    "@lezer/lr": "^1.2.5"
   },
   "repository": {
     "type" : "git",


### PR DESCRIPTION
update dependencies
increment version

todo: release to npm

with the latest `@lezer/lr` the parser throws

> TypeError: this.input.chunk is not a function
