### PR TITLE
Extend `using` declaration to support list of members

### DIFF
--- a/src/cpp.grammar
+++ b/src/cpp.grammar
@@ -800,8 +800,12 @@ NamespaceDefinition {
   (CompoundStatement | "=" (Identifier | ScopedIdentifier) ";")
 }
 
+ScopedIdentifierList {
+  ScopedIdentifier ("," ScopedIdentifier)*
+}
+
 UsingDeclaration {
-  kw<"using"> (kw<"namespace"> | kw<"enum">)? (Identifier | ScopedIdentifier) ";"
+  kw<"using"> (kw<"namespace"> | kw<"enum">)? (Identifier | ScopedIdentifierList) ";"
 }
 
 AliasDeclaration {


### PR DESCRIPTION
C++17 and up allows a list of members to be imported:

```cpp
namespace X
{
    using A::g, A::g; // (C++17) OK: double declaration allowed at namespace scope
}
```

Source - https://en.cppreference.com/w/cpp/language/namespace.html

Currently, the cpp parser behaves inconsistently:

```cpp
#include <cstdlib>
#include <iostream>

using std::cout, std::endl;
//          ^          ^ variableName
//          ^ namespace
int main() {
    cout << "hello" << endl;
    return 0;
}

```

Honestly, I don't know how it even parses it at all right now, but I replaced `ScopedIdentifier` with a new simple comma-separated list `ScopedIdentiferList` for the `UsingDeclaration`, and now both member names are recognised as `tok-variableName`s.